### PR TITLE
Auto caption placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ A link to the original file and a list of changes is noted above.
 ## RPI's Provided Template
 
 The files in the `template` folder contain the RPI thesis template tex files (originally provided by dotCIO).
-The only change exists in [rpithes.tex:27](https://github.com/gonsie/rpi-latex-thesis/blob/master/template/rpithes.tex#L27) and it is for the self attribution required by the OGE Thesis Manual (page 12).
+
+There are two changes:
+1. In [rpithes.tex:32](https://github.com/gonsie/rpi-latex-thesis/blob/master/template/rpithes.tex#L32) for the self attribution required by the OGE Thesis Manual (page 12).
+2. In [rpithes.tex:15](https://github.com/gonsie/rpi-latex-thesis/blob/master/template/rpithes.tex#L15) for automated figure caption placement below the figure, and table caption placement above the figure. As well as caption bolding and centering.
 
 ## RPI/OGE Forms
 

--- a/template/rpithes.tex
+++ b/template/rpithes.tex
@@ -12,13 +12,17 @@
 
 \documentclass[chap]{thesis}
 
-% Use the first command below if you want captions over 1 line indented. A side
-% effect of this is to remove the use of bold for captions (thesis default).
-% To restore bold, also include the second line below.
-%\usepackage[hang]{caption}      % to indent subsequent lines of captions
-%\renewcommand{\captionfont}{\bfseries} % bold caption (needed with caption
-                                       % package to restore boldface.)
-
+%packages to automate the placement of captions below Figures, above Tables,
+% and the bolding of these captions.
+% Note: if you will also \usepackage{algorithm} or another package that will call \usepackage{float}
+%  you must invoke those use-packages AFTER you invoke \usepackage{floatrow}
+\usepackage[font=bf,labelfont=bf,labelsep=colon,
+justification=centerlast]{caption}
+\usepackage{floatrow}
+\usepackage[tableposition=top]{caption}
+\floatsetup[table]{capposition=top}
+\usepackage[margin=1in]{geometry}
+%\usepackage{algorithm}
 
 %\includeonly{rpichap1}  % use \includeonly to process only
                          % the file(s) listed inside the braces


### PR DESCRIPTION
Added packages to rpithes.tex and documentation to README.md in order to automate the placement of figure and table captions, and their formatting.

Courtesy of Amar V.